### PR TITLE
Fix muiltiple receive transactions.

### DIFF
--- a/cliqueledger/lib/service/socket_event_handler.dart
+++ b/cliqueledger/lib/service/socket_event_handler.dart
@@ -54,7 +54,6 @@ class SocketEventHandler {
       
       cliqueListProvider!.setClique(clique);
       
-      socket!.emit('join-rooms', jsonEncode([clique.id]));
 
     } catch (err) {
       debugPrint(


### PR DESCRIPTION
When a user was added to a clique we were emiting join-rooms event over the socket. Which was wrong as that event was designed for joining all the rooms and not a single room. Which was causing the user to join to a room multiple times which lead to some inconsistent behavour such as receiving a transaction multiple times.
Now the joining to a single room logic is being handled on the backend at the time when the user is added to the group.

fixes #42